### PR TITLE
fix: add filter option on populate and verify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/jenkins-x/jx-api/v4 v4.0.14
-	github.com/jenkins-x/jx-helpers/v3 v3.0.29
+	github.com/jenkins-x/jx-helpers/v3 v3.0.35
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.1
 	github.com/jenkins-x/jx-logging/v3 v3.0.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/jenkins-x/jx-api/v4 v4.0.11 h1:O+kfza0EvHkRhbOTS7OnO6F2f9qF4RT4xcfnjP
 github.com/jenkins-x/jx-api/v4 v4.0.11/go.mod h1:3n+xwDoSuALVUSlIUj8nK105k7hqP5HoTh7cch/FScc=
 github.com/jenkins-x/jx-api/v4 v4.0.14 h1:bNVvZJH/BOHRjMFQP/QC64pSWfqIy3SSdVUlEgBcDxU=
 github.com/jenkins-x/jx-api/v4 v4.0.14/go.mod h1:3n+xwDoSuALVUSlIUj8nK105k7hqP5HoTh7cch/FScc=
-github.com/jenkins-x/jx-helpers/v3 v3.0.29 h1:ueVTYYsxhm2RFlUlHBMoXxP6Wu2e/HSrmLF6oVr+g48=
-github.com/jenkins-x/jx-helpers/v3 v3.0.29/go.mod h1:nmXx3EyNNco3C3BOumzKysDMgz3YQuGtG7PxS+1KPSI=
+github.com/jenkins-x/jx-helpers/v3 v3.0.35 h1:9sQV5wu6bea2JGLBUAgpzZEN4xG2syGqp3Ec+PdhCc0=
+github.com/jenkins-x/jx-helpers/v3 v3.0.35/go.mod h1:nmXx3EyNNco3C3BOumzKysDMgz3YQuGtG7PxS+1KPSI=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1 h1:zMnxoLRXJJ85PAd9OVPlgXT5T8xHgbmxSMhpYPTF5mw=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1/go.mod h1:0CYp1ACEgSmOxul1bx5qbZgQGEcyAeGdBOBa+u62zZY=
 github.com/jenkins-x/jx-logging/v3 v3.0.0/go.mod h1:bOYlj+Cdd9v7/vDXjkwlUylxGs5sfQJvYnuYbCL0IrY=

--- a/pkg/cmd/convert/convert.go
+++ b/pkg/cmd/convert/convert.go
@@ -472,6 +472,9 @@ func (o *Options) modifyGSM(rNode *yaml.RNode, field, secretName, path string) e
 	if err != nil {
 		return err
 	}
+	if property == "" {
+		property = field
+	}
 	if property != "" {
 		err = kyamls.SetStringValue(rNode, path, property, "property")
 		if err != nil {

--- a/pkg/cmd/populate/populate.go
+++ b/pkg/cmd/populate/populate.go
@@ -64,6 +64,8 @@ func NewCmdPopulate() (*cobra.Command, *Options) {
 	cmd.Flags().StringVarP(&o.Dir, "dir", "d", ".", "the directory to look for the .jx/secret/mapping/secret-mappings.yaml file")
 	cmd.Flags().BoolVarP(&o.NoWait, "no-wait", "", false, "disables waiting for the secret store (e.g. vault) to be available")
 	cmd.Flags().DurationVarP(&o.WaitDuration, "wait", "w", 2*time.Hour, "the maximum time period to wait for the vault pod to be ready if using the vault backendType")
+
+	o.Options.AddFlags(cmd)
 	return cmd, o
 }
 
@@ -151,6 +153,9 @@ func (o *Options) populateLoop(results []*secretfacade.SecretPair, waited map[st
 			d := &data[i]
 			key := d.Key
 			property := d.Property
+			if property == "" {
+				property = d.Name
+			}
 			keyProperties := m[key]
 			if keyProperties == nil {
 				keyProperties = &editor.KeyProperties{

--- a/pkg/cmd/verify/verify.go
+++ b/pkg/cmd/verify/verify.go
@@ -48,6 +48,7 @@ func NewCmdVerify() (*cobra.Command, *Options) {
 		},
 	}
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "the namespace to filter the ExternalSecret resources")
+	o.Options.AddFlags(cmd)
 	return cmd, o
 }
 

--- a/pkg/extsecrets/secretfacade/types.go
+++ b/pkg/extsecrets/secretfacade/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jenkins-x/jx-secret/pkg/extsecrets/editor"
 	"github.com/jenkins-x/jx-secret/pkg/schemas"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -15,6 +16,7 @@ import (
 type Options struct {
 	Dir          string
 	Namespace    string
+	Filter       string
 	SecretClient extsecrets.Interface
 	KubeClient   kubernetes.Interface
 
@@ -23,6 +25,10 @@ type Options struct {
 
 	// EditorCache the optional cache of editors
 	EditorCache map[string]editor.Interface
+}
+
+func (o *Options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Filter, "filter", "f", "", "the filter to filter on ExternalSecret names")
 }
 
 // SecretError returns an error for a secret

--- a/pkg/extsecrets/secretfacade/verify.go
+++ b/pkg/extsecrets/secretfacade/verify.go
@@ -1,6 +1,8 @@
 package secretfacade
 
 import (
+	"strings"
+
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/pkg/errors"
 )
@@ -17,6 +19,9 @@ func (o *Options) Verify() ([]*SecretPair, error) {
 		r := p.ExternalSecret
 		secret := p.Secret
 		name := r.Name
+		if o.Filter != "" && !strings.Contains(name, o.Filter) {
+			continue
+		}
 		ns := r.Namespace
 		result, err := VerifySecret(&r, secret)
 		if err != nil {


### PR DESCRIPTION
also fix gremlin where non-mapped GSM secrets don't have property names defined which causes bad secrets to be populated

Signed-off-by: James Strachan <james.strachan@gmail.com>