### PR TITLE
fix: disable retry on templates by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/jenkins-x/jx-api/v4 v4.0.14
-	github.com/jenkins-x/jx-helpers/v3 v3.0.35
+	github.com/jenkins-x/jx-helpers/v3 v3.0.39
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.1
 	github.com/jenkins-x/jx-logging/v3 v3.0.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/jenkins-x/jx-api/v4 v4.0.11 h1:O+kfza0EvHkRhbOTS7OnO6F2f9qF4RT4xcfnjP
 github.com/jenkins-x/jx-api/v4 v4.0.11/go.mod h1:3n+xwDoSuALVUSlIUj8nK105k7hqP5HoTh7cch/FScc=
 github.com/jenkins-x/jx-api/v4 v4.0.14 h1:bNVvZJH/BOHRjMFQP/QC64pSWfqIy3SSdVUlEgBcDxU=
 github.com/jenkins-x/jx-api/v4 v4.0.14/go.mod h1:3n+xwDoSuALVUSlIUj8nK105k7hqP5HoTh7cch/FScc=
-github.com/jenkins-x/jx-helpers/v3 v3.0.35 h1:9sQV5wu6bea2JGLBUAgpzZEN4xG2syGqp3Ec+PdhCc0=
-github.com/jenkins-x/jx-helpers/v3 v3.0.35/go.mod h1:nmXx3EyNNco3C3BOumzKysDMgz3YQuGtG7PxS+1KPSI=
+github.com/jenkins-x/jx-helpers/v3 v3.0.39 h1:ZpKUz3EPz/Rv+7zhZBjAyaA5euRhUTUXS6wO+2SYUSM=
+github.com/jenkins-x/jx-helpers/v3 v3.0.39/go.mod h1:nmXx3EyNNco3C3BOumzKysDMgz3YQuGtG7PxS+1KPSI=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1 h1:zMnxoLRXJJ85PAd9OVPlgXT5T8xHgbmxSMhpYPTF5mw=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1/go.mod h1:0CYp1ACEgSmOxul1bx5qbZgQGEcyAeGdBOBa+u62zZY=
 github.com/jenkins-x/jx-logging/v3 v3.0.0/go.mod h1:bOYlj+Cdd9v7/vDXjkwlUylxGs5sfQJvYnuYbCL0IrY=

--- a/pkg/apis/schema/v1alpha1/types.go
+++ b/pkg/apis/schema/v1alpha1/types.go
@@ -110,6 +110,9 @@ type Property struct {
 	// define the template in the schema
 	Template string `json:"template,omitempty" yaml:"template,omitempty"`
 
+	// Retry enable a retry loop if a template does not evaluate correctly first time
+	Retry bool `json:"retry,omitempty" yaml:"retry,omitempty"`
+
 	// Labels allows arbitrary metadata labels to be associated with the property
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 

--- a/pkg/cmd/populate/populate.go
+++ b/pkg/cmd/populate/populate.go
@@ -241,7 +241,7 @@ func (o *Options) generateSecretValue(s *secretfacade.SecretPair, secretName, pr
 
 	templateText := propertySchema.Template
 	if templateText != "" {
-		return o.EvaluateTemplate(s.ExternalSecret.Namespace, secretName, property, templateText)
+		return o.EvaluateTemplate(s.ExternalSecret.Namespace, secretName, property, templateText, propertySchema.Retry)
 	}
 
 	// for now don't regenerate if we have a current value

--- a/pkg/cmd/populate/templatertesting/run.go
+++ b/pkg/cmd/populate/templatertesting/run.go
@@ -57,7 +57,7 @@ func (r *Runner) Run(t *testing.T) {
 		templateText := property.Template
 		require.NotEmpty(t, templateText, "no template defined for object %s property name %s", objName, propName)
 
-		text, err := o.EvaluateTemplate(r.Namespace, objName, propName, templateText)
+		text, err := o.EvaluateTemplate(r.Namespace, objName, propName, templateText, false)
 		require.NoError(t, err, "failed to evaluate template for object %s property name %s", objName, propName)
 
 		message := fmt.Sprintf("test %s for object %s property name %s", tc.TestName, objName, propName)


### PR DESCRIPTION
and enable on a per secret basic when required to avoid slowing things down
unnecessarily