### PR TITLE
fix: support populating from helm secrets with stringData

### DIFF
--- a/pkg/cmd/populate/populate.go
+++ b/pkg/cmd/populate/populate.go
@@ -490,10 +490,11 @@ func (o *Options) helmSecretValue(s *secretfacade.SecretPair, entryName string) 
 		}
 
 		values = map[string]string{}
-		if secret.Data != nil {
-			for k, v := range secret.Data {
-				values[k] = string(v)
-			}
+		for k, v := range secret.Data {
+			values[k] = string(v)
+		}
+		for k, v := range secret.StringData {
+			values[k] = v
 		}
 		o.HelmSecretValues[key] = values
 	}

--- a/pkg/cmd/populate/populate_test.go
+++ b/pkg/cmd/populate/populate_test.go
@@ -356,4 +356,5 @@ func TestPopulateFromHelmSecrets(t *testing.T) {
 
 	fakeStore := fakeFactory.GetSecretStore()
 	fakeStore.AssertValueEquals(t, secretLocation, "lighthouse-oauth-token", "token", "fake-secret-value")
+	fakeStore.AssertValueEquals(t, secretLocation, "secret-with-stringdata", "token", "token-value")
 }

--- a/pkg/cmd/populate/test_data/populate_helm_secrets/extsecrets/secret-with-stringdata.yaml
+++ b/pkg/cmd/populate/test_data/populate_helm_secrets/extsecrets/secret-with-stringdata.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: secret-with-stringdata
+  namespace: jx
+spec:
+  backendType: azureKeyVault
+  keyVaultName: azureSuperSecretVault
+  data:
+  - key: secret-with-stringdata
+    name: token
+    property: token
+  template:
+    metadata:
+      labels:
+        app: some-app
+    type: Opaque

--- a/pkg/cmd/populate/test_data/populate_helm_secrets/fake-helm-secrets/jx/secret-with-stringdata.yaml
+++ b/pkg/cmd/populate/test_data/populate_helm_secrets/fake-helm-secrets/jx/secret-with-stringdata.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+stringData:
+  token: token-value
+kind: Secret
+metadata:
+  name: secret-with-stringdata
+  namespace: jx
+type: Opaque


### PR DESCRIPTION
sometimes Helm charts provides secrets with only `stringData` fields
such as https://github.com/grafana/helm-charts/blob/promtail-3.4.0/charts/promtail/templates/secret.yaml

this fixes the `populate` cmd by also reading values from the `stringData` fields